### PR TITLE
Align protected category excerpt hiding with options

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -270,13 +270,11 @@ function getProtectedCategorySlug($archive) {
         return null;
     }
     
-    // 如果是单篇文章页面，检查文章所属分类
-    if ($archive->is('single')) {
-        if (!empty($archive->categories)) {
-            foreach ($archive->categories as $category) {
-                if (in_array($category['slug'], $protectedSlugs)) {
-                    return $category['slug'];
-                }
+    // 检查文章所属分类（在列表页和文章页都需要检测，避免摘要泄露）
+    if (!empty($archive->categories)) {
+        foreach ($archive->categories as $category) {
+            if (in_array($category['slug'], $protectedSlugs)) {
+                return $category['slug'];
             }
         }
     }
@@ -710,9 +708,10 @@ function printExcerpt($archive, $length = 140) {
         // 获取配置选项
         $hideFromHome = !empty($options->hideProtectedCategoriesFromHome) && $options->hideProtectedCategoriesFromHome == '1';
         $requireArchivePassword = empty($options->requireCategoryArchivePassword) || $options->requireCategoryArchivePassword == '1';
-        
+
         // 判断是否需要隐藏摘要
-        $shouldHideExcerpt = $hideFromHome || !$requireArchivePassword || !isPasswordVerified($archive);
+        // 需求：如果首页隐藏开启，或分类归档无需密码，则不显示摘要内容
+        $shouldHideExcerpt = $hideFromHome || !$requireArchivePassword;
         
         if ($shouldHideExcerpt) {
             $lang = $options->languageSetting;


### PR DESCRIPTION
## Summary
- hide excerpts for category-protected posts when either home hiding is enabled or category archives skip password validation, matching configuration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693957ec2e688326898615cb382bc1e7)